### PR TITLE
[DOD 901] Add sort schema

### DIFF
--- a/graphlayer/graphql/__init__.py
+++ b/graphlayer/graphql/__init__.py
@@ -6,16 +6,22 @@ from . import parser
 from .schema import create_graphql_schema
 
 
-def execute(document_text, *, graph, query_type, mutation_type=None, types=None, variables=None):
+def execute(document_text, *, graph, query_type, mutation_type=None, types=None, variables=None, sort_schema=False):
     return executor(
         query_type=query_type,
         mutation_type=mutation_type,
         types=types,
+        sort_schema=sort_schema,
     )(document_text, graph=graph, variables=variables)
 
 
-def executor(*, query_type, mutation_type=None, types=None):
-    graphql_schema = create_graphql_schema(query_type=query_type, mutation_type=mutation_type, types=types)
+def executor(*, query_type, mutation_type=None, types=None, sort_schema=False):
+    graphql_schema = create_graphql_schema(
+        query_type=query_type,
+        mutation_type=mutation_type,
+        types=types,
+        sort_schema=sort_schema,
+    )
 
     def execute(document_text, *, graph, variables=None):
         try:

--- a/graphlayer/graphql/schema.py
+++ b/graphlayer/graphql/schema.py
@@ -1,4 +1,5 @@
 import graphql
+from graphql import lexicographic_sort_schema
 
 from .. import iterables, schema
 from .naming import snake_case_to_camel_case
@@ -12,7 +13,7 @@ class Schema(object):
         self.graphql_schema = graphql_schema
 
 
-def create_graphql_schema(query_type, mutation_type, types=None):
+def create_graphql_schema(query_type, mutation_type=None, types=None, sort_schema=False):
     if types is None:
         types = ()
 
@@ -118,15 +119,21 @@ def create_graphql_schema(query_type, mutation_type, types=None):
     for extra_type in types:
         to_graphql_type(extra_type)
 
+    graphql_schema = graphql.GraphQLSchema(
+        query=graphql_query_type,
+        mutation=graphql_mutation_type,
+        types=tuple(map(_to_base_type, graphql_types.values())),
+    )
+
+    if sort_schema:
+        # Apply lexicographic sorting for consistent field ordering in documentation
+        graphql_schema = lexicographic_sort_schema(graphql_schema)
+
     return Schema(
         query_type=query_type,
         mutation_type=mutation_type,
         types=types,
-        graphql_schema=graphql.GraphQLSchema(
-            query=graphql_query_type,
-            mutation=graphql_mutation_type,
-            types=tuple(map(_to_base_type, graphql_types.values())),
-        ),
+        graphql_schema=graphql_schema,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
     name='graphlayer',
-    version='0.2.8',
+    version='0.3.0',
     description='High-performance library for implementing GraphQL APIs',
     long_description=read("README.rst"),
     author='Michael Williamson',

--- a/tests/graphql/test_graphql.py
+++ b/tests/graphql/test_graphql.py
@@ -240,3 +240,78 @@ def is_success(*, data):
 
 def has_str(matcher):
     return has_feature("str", str, matcher)
+
+
+def test_sorted_schema_still_resolves_data_correctly():
+    """Test that sorting the schema doesn't affect data resolution."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("zebra", g.String),
+        g.field("apple", g.String),
+        g.field("mango", g.String),
+    ))
+
+    root_resolver = g.root_object_resolver(Root)
+
+    @root_resolver.field(Root.fields.zebra)
+    def root_resolve_zebra(graph, query, args):
+        return "zebra_value"
+
+    @root_resolver.field(Root.fields.apple)
+    def root_resolve_apple(graph, query, args):
+        return "apple_value"
+
+    @root_resolver.field(Root.fields.mango)
+    def root_resolve_mango(graph, query, args):
+        return "mango_value"
+
+    graph_definition = g.define_graph(resolvers=(root_resolver, ))
+    graph = graph_definition.create_graph({})
+
+    query = """
+        query {
+            zebra
+            apple
+            mango
+        }
+    """
+
+    execute = graphql.executor(query_type=Root, sort_schema=True)
+    result = execute(graph=graph, document_text=query)
+
+    # Data should be resolved correctly regardless of sorting
+    assert_that(result, is_success(data=equal_to({
+        "zebra": "zebra_value",
+        "apple": "apple_value",
+        "mango": "mango_value",
+    })))
+
+
+def test_sorted_schema_with_field_arguments():
+    """Test that sorted schema correctly handles fields with arguments."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("greeting", g.String, params=(
+            g.param("name", g.String),
+        )),
+    ))
+
+    root_resolver = g.root_object_resolver(Root)
+
+    @root_resolver.field(Root.fields.greeting)
+    def root_resolve_greeting(graph, query, args):
+        return f"Hello, {args.name}!"
+
+    graph_definition = g.define_graph(resolvers=(root_resolver, ))
+    graph = graph_definition.create_graph({})
+
+    query = """
+        query {
+            greeting(name: "World")
+        }
+    """
+
+    execute = graphql.executor(query_type=Root, sort_schema=True)
+    result = execute(graph=graph, document_text=query)
+
+    assert_that(result, is_success(data=equal_to({
+        "greeting": "Hello, World!",
+    })))

--- a/tests/graphql/test_schema_sorting.py
+++ b/tests/graphql/test_schema_sorting.py
@@ -1,0 +1,189 @@
+"""Tests for schema sorting functionality."""
+import enum
+
+from precisely import assert_that, contains_exactly, equal_to
+
+import graphlayer as g
+from graphlayer.graphql.schema import create_graphql_schema
+
+
+def test_fields_are_sorted_alphabetically_when_sort_schema_is_true():
+    """Test that object type fields are sorted alphabetically."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("zebra", g.String),
+        g.field("apple", g.String),
+        g.field("mango", g.String),
+        g.field("banana", g.String),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=True)
+    field_names = list(schema.graphql_schema.query_type.fields.keys())
+
+    assert_that(field_names, equal_to(["apple", "banana", "mango", "zebra"]))
+
+
+def test_fields_preserve_definition_order_when_sort_schema_is_false():
+    """Test that object type fields preserve definition order when not sorted."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("zebra", g.String),
+        g.field("apple", g.String),
+        g.field("mango", g.String),
+        g.field("banana", g.String),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=False)
+    field_names = list(schema.graphql_schema.query_type.fields.keys())
+
+    assert_that(field_names, equal_to(["zebra", "apple", "mango", "banana"]))
+
+
+def test_field_arguments_are_sorted_alphabetically_when_sort_schema_is_true():
+    """Test that field arguments are sorted alphabetically."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("value", g.String, params=(
+            g.param("zebra", g.Int),
+            g.param("apple", g.Int),
+            g.param("mango", g.Int),
+            g.param("banana", g.Int),
+        )),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=True)
+    arg_names = list(schema.graphql_schema.query_type.fields["value"].args.keys())
+
+    assert_that(arg_names, equal_to(["apple", "banana", "mango", "zebra"]))
+
+
+def test_enum_values_are_sorted_alphabetically_when_sort_schema_is_true():
+    """Test that enum values are sorted alphabetically."""
+    class Color(enum.Enum):
+        red = "RED"
+        green = "GREEN"
+        blue = "BLUE"
+        yellow = "YELLOW"
+
+    ColorType = g.EnumType(Color)
+
+    Root = g.ObjectType("Root", fields=(
+        g.field("color", ColorType),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=True)
+
+    # Find the Color enum type in the schema
+    color_enum_type = None
+    for type_obj in schema.graphql_schema.type_map.values():
+        if hasattr(type_obj, 'name') and type_obj.name == "Color":
+            color_enum_type = type_obj
+            break
+
+    assert color_enum_type is not None, "Color enum type not found in schema"
+
+    enum_value_names = list(color_enum_type.values.keys())
+    assert_that(enum_value_names, equal_to(["BLUE", "GREEN", "RED", "YELLOW"]))
+
+
+def test_nested_type_fields_are_sorted_when_sort_schema_is_true():
+    """Test that nested object type fields are also sorted."""
+    NestedType = g.ObjectType("Nested", fields=(
+        g.field("zebra", g.String),
+        g.field("apple", g.String),
+    ))
+
+    Root = g.ObjectType("Root", fields=(
+        g.field("nested", NestedType),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=True)
+
+    # Get the Nested type from the schema
+    nested_type = schema.graphql_schema.type_map["Nested"]
+    field_names = list(nested_type.fields.keys())
+
+    assert_that(field_names, equal_to(["apple", "zebra"]))
+
+
+def test_mutation_fields_are_sorted_when_sort_schema_is_true():
+    """Test that mutation type fields are sorted alphabetically."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("value", g.String),
+    ))
+
+    Mutation = g.ObjectType("Mutation", fields=(
+        g.field("updateZebra", g.String),
+        g.field("createApple", g.String),
+        g.field("deleteMango", g.String),
+    ))
+
+    schema = create_graphql_schema(
+        query_type=Root,
+        mutation_type=Mutation,
+        sort_schema=True,
+    )
+
+    mutation_field_names = list(schema.graphql_schema.mutation_type.fields.keys())
+    assert_that(mutation_field_names, equal_to(["createApple", "deleteMango", "updateZebra"]))
+
+
+def test_input_object_fields_are_sorted_when_sort_schema_is_true():
+    """Test that input object type fields are sorted alphabetically."""
+    InputType = g.InputObjectType("Input", fields=(
+        g.input_field("zebra", g.String),
+        g.input_field("apple", g.String),
+        g.input_field("mango", g.String),
+    ))
+
+    Root = g.ObjectType("Root", fields=(
+        g.field("process", g.String, params=(
+            g.param("input", InputType),
+        )),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=True)
+
+    input_type = schema.graphql_schema.type_map["Input"]
+    field_names = list(input_type.fields.keys())
+
+    assert_that(field_names, equal_to(["apple", "mango", "zebra"]))
+
+
+def test_sort_schema_defaults_to_false():
+    """Test that sort_schema defaults to False (preserves definition order)."""
+    Root = g.ObjectType("Root", fields=(
+        g.field("zebra", g.String),
+        g.field("apple", g.String),
+    ))
+
+    # Call without sort_schema parameter
+    schema = create_graphql_schema(query_type=Root)
+    field_names = list(schema.graphql_schema.query_type.fields.keys())
+
+    # Should preserve definition order (not sorted)
+    assert_that(field_names, equal_to(["zebra", "apple"]))
+
+
+def test_types_are_sorted_in_type_map_when_sort_schema_is_true():
+    """Test that type names in the type map are sorted alphabetically."""
+    TypeZ = g.ObjectType("TypeZ", fields=(g.field("value", g.String),))
+    TypeA = g.ObjectType("TypeA", fields=(g.field("value", g.String),))
+    TypeM = g.ObjectType("TypeM", fields=(g.field("value", g.String),))
+
+    Root = g.ObjectType("Root", fields=(
+        g.field("z", TypeZ),
+        g.field("a", TypeA),
+        g.field("m", TypeM),
+    ))
+
+    schema = create_graphql_schema(query_type=Root, sort_schema=True, types=(TypeZ, TypeA, TypeM))
+
+    # Filter out built-in types (those starting with __)
+    custom_type_names = [
+        name for name in schema.graphql_schema.type_map.keys()
+        if not name.startswith("__")
+    ]
+
+    # Check that custom types appear in sorted order
+    # Only String and Boolean are present because the fields use g.String type
+    assert_that(custom_type_names, contains_exactly(
+        "Boolean", "Root", "String", "TypeA", "TypeM", "TypeZ"
+    ))

--- a/tests/graphql/test_schema_sorting.py
+++ b/tests/graphql/test_schema_sorting.py
@@ -182,8 +182,8 @@ def test_types_are_sorted_in_type_map_when_sort_schema_is_true():
         if not name.startswith("__")
     ]
 
-    # Check that custom types appear in sorted order
-    # Only String and Boolean are present because the fields use g.String type
+    # Check that non-introspection types (built-ins and custom object types)
+    # appear in sorted order: Boolean, Root, String, TypeA, TypeM, TypeZ
     assert_that(custom_type_names, contains_exactly(
         "Boolean", "Root", "String", "TypeA", "TypeM", "TypeZ"
     ))


### PR DESCRIPTION

  Add optional sort_schema parameter to create_graphql_schema(), executor(), and execute() functions to enable lexicographic sorting of GraphQL schemas. This provides consistent field ordering for documentation and introspection.

  - Applies GraphQL's lexicographic_sort_schema when sort_schema=True
  - Defaults to False to preserve backward compatibility
  - Sorts fields, arguments, enums, mutations, and input object fields
  - Add comprehensive test coverage (11 new tests)

  This enables clean schema generation for documentation without requiring monkey-patching or wrapper functions in consuming applications.