### PR TITLE
Bump version from 0.3.0 to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
     name='graphlayer',
-    version='0.3.0',
+    version='0.4.0',
     description='High-performance library for implementing GraphQL APIs',
     long_description=read("README.rst"),
     author='Michael Williamson',


### PR DESCRIPTION
This pull request updates the version of the `graphlayer` package in `setup.py` from 0.3.0 to 0.4.0.

- Version bump:
  * Updated the `version` field in `setup.py` from '0.3.0' to '0.4.0' to reflect a new release.